### PR TITLE
bug修复--解决页面初始化时的两个警告；解决列名为空时赋值原值

### DIFF
--- a/src/MainPage.js
+++ b/src/MainPage.js
@@ -77,7 +77,6 @@ export default class MainPage extends React.Component {
               <Panel header={<h3 style={{fontWeight:"bold",color:'#767676'}}>工作板区</h3>} showArrow={false} key="1">
                 <Search
                   placeholder="搜索"
-                  bordered={false}
                   onSearch={value => console.log(value)}
                   style={{margin:'0 0 5px 0' }}
                 />

--- a/src/helpers/columnlib/header/EditableCell.js
+++ b/src/helpers/columnlib/header/EditableCell.js
@@ -22,6 +22,7 @@ class EditableCell extends React.PureComponent {
        let cellData = this.getCellData(props)
        this.state = {
             value: cellData.value,
+            oldValue: cellData.value, // 保留原值
             isCollapsed: cellData.isCollapsed,
             editing: false,
             type:'TEXT',
@@ -85,7 +86,12 @@ class EditableCell extends React.PureComponent {
             }
             else {
               // 修改列名
-              this.props.data.setColumnData(this.props.columnKey, {name: this.state.value})
+              if (this.state.value) {
+                this.props.data.setColumnData(this.props.columnKey, {name: this.state.value})
+              }
+              else {
+                this.props.data.setColumnData(this.props.columnKey, {name: this.state.oldValue})
+              }
             }
           }
     }

--- a/src/maintable/MainTable.js
+++ b/src/maintable/MainTable.js
@@ -150,7 +150,7 @@ const DataSectionHeader = function(props) {
 
 const FilterableDataTable = AddFilter(DataContext(Table));
 
-@connect(mapRowActionStateToProps)
+@connect(mapRowActionStateToProps, null, null, { forwardRef: true })
 class MainTable extends React.Component {
 
     static propTypes = {
@@ -425,7 +425,7 @@ class MainTable extends React.Component {
       
         return (
          <TableContext.Provider value={this.state}>
-            <div id={'appTable'}>
+            <div>
                 <FilterableDataTable
                     ref={this.handleRef}
                     onColumnReorderEndCallback={this._onColumnReorderEndCallback}


### PR DESCRIPTION
bug修复--解决页面初始化时的两个警告；解决列名为空时赋值原值（缺陷：现在的代码捕获输入框变化时即调用设置数据的方法，导致抓取的原列名值有问题，需要张涛帮忙看下，这部分主要是他进行修改的）