### PR TITLE
bug解决及isHeaderOrFooter红色警告

### DIFF
--- a/src/helpers/columnlib/cell/DateCell.js
+++ b/src/helpers/columnlib/cell/DateCell.js
@@ -49,9 +49,11 @@ class DateCell extends React.Component {
       })
     }
     checkedAddTime = (v,o) => {
+      const date = this.state.value;
       const addDateTime = o.children[0]+o.children[1];
       this.setState({
         addDateTime:addDateTime,
+        value:date!=''?date:moment(),
         open:true
       })
 

--- a/src/helpers/columnlib/cell/StatusCell.js
+++ b/src/helpers/columnlib/cell/StatusCell.js
@@ -36,7 +36,8 @@ class StatusCell extends React.Component {
     render() {
       const {data, rowIndex, columnKey, collapsedRows, callback, value, handleChange, handleKey, ...props} = this.props;
       const returnValue = (e) => {
-        const statusValue = e.key?e.item.props.children:'';
+        const selectedText = e.item.props.children;
+        const statusValue = selectedText?selectedText:'';
         this.setState({
           value:statusValue
         })
@@ -61,9 +62,9 @@ class StatusCell extends React.Component {
       return (
         <Cell {...props} style={{ width: '100%' }}>
             <Dropdown overlay={menu} trigger={['click']}>
-              <Button style={this.getSelectedStatusColor(this.state.value)} className="statusWidth">
+              <div style={this.getSelectedStatusColor(this.state.value)} className="statusWidth longText">
                   {this.state.value}
-              </Button>
+              </div>
             </Dropdown>
         </Cell>
       );

--- a/src/helpers/columnlib/cell/TableCell.js
+++ b/src/helpers/columnlib/cell/TableCell.js
@@ -17,7 +17,7 @@ class TableCell extends React.Component{
     initCellHashTable(table){
       const cellHashTable = {
           PEOPLE:<PeopleCell  value={table.value} handleChange={table.handleChange} handleKey={table.handleKey}/>,
-          TEXT:<TextCell  value={table.value} isHeaderOrFooter handleChange={table.handleChange} handleKey={table.handleKey}/>,
+          TEXT:<TextCell  value={table.value} isHeaderOrFooter={table.isHeaderOrFooter} handleChange={table.handleChange} handleKey={table.handleKey}/>,
           NUMBER:<NumberCell  value={table.value} handleChange={table.handleChange} handleKey={table.handleKey}/>,
           SELECT:<SelectCell  value={table.value} handleChange={table.handleChange} handleKey={table.handleKey}/>,
           DATE:<DateCell  value={table.value} handleChange={table.handleChange} handleKey={table.handleKey}/>,

--- a/src/helpers/columnlib/cell/TextCell.js
+++ b/src/helpers/columnlib/cell/TextCell.js
@@ -13,7 +13,7 @@ class TextCell extends React.Component {
       }
     }
     render() {
-      const {data, rowIndex, columnKey, collapsedRows, callback, value, handleChange, handleKey, ...props} = this.props;
+      const {data, rowIndex, columnKey, collapsedRows, isHeaderOrFooter, callback, value, handleChange, handleKey, ...props} = this.props;
       const returnValue = (e) => {
         const inputValue = e.target.value;
         this.setState({

--- a/src/helpers/columnlib/header/EditableCell.js
+++ b/src/helpers/columnlib/header/EditableCell.js
@@ -176,8 +176,7 @@ class EditableCell extends React.PureComponent {
                             <div
                                 {...props}
                                 style={{
-                                    ...props.style,
-                                    width: this.targetRef.offsetWidth,
+                                    width: '100%',
                                     top:
                                         placement === 'top'
                                             ? this.targetRef.offsetHeight

--- a/src/maintable/css/style/TableCellComponent.css
+++ b/src/maintable/css/style/TableCellComponent.css
@@ -1,7 +1,12 @@
  .statusWidth{
-     min-width: 70px;
+     min-width: 50px !important;
      width: 100%;
      color:white;
+     margin:0px !important;
+     cursor: pointer;
+     height: 30px;
+     line-height: 30px;
+     text-align: center;
  }
  .status:after {
     content:"";


### PR DESCRIPTION
BUG解决如下：
一：3/23 文本列超出界面时，单元格的输入框没有和单元格对齐
二：体验：状态列极限最小列宽太窄，可以增加极限最小列宽保证状态标签中的文字始终居中，长文字部分不显示，显示“...”
三：isHeaderOrFooter红色警告
四：日期控件若没选选日期给默认当前时间